### PR TITLE
Updates for arity = 0 functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /deps
 erl_crash.dump
 *.ez
+/_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ otp_release:
   - R16B
 before_install:
   - mkdir -p vendor/elixir
-  - wget -q https://github.com/elixir-lang/elixir/releases/download/v0.10.1/v0.10.1.zip && unzip -qq v0.10.1.zip -d vendor/elixir
+  - wget -q https://github.com/elixir-lang/elixir/releases/download/v0.11.2/v0.11.2.zip && unzip -qq v0.11.2.zip -d vendor/elixir
   - export PATH="$PATH:$PWD/vendor/elixir/bin"

--- a/test/future_test.exs
+++ b/test/future_test.exs
@@ -44,6 +44,12 @@ defmodule FutureTest do
     assert 3 == Future.value(f1)
   end
 
+  test "a future with no arguments" do
+    f = Future.new(fn -> 3 * 3 end)
+    f1 = f.()
+    assert 9 == Future.value(f1)
+  end
+
   test "calling a future with a non function value raises an error" do
     assert_compile_fail Future.Error, "import Future; Future.new(10)"
   end


### PR DESCRIPTION
Hi, I was searching for future library, and this one sounds nice.
While I was playing around it, I faced a BadArityError when using arity = 0 function, and tried to modify some. What do you think?

```
** (BadArityError) bad arity error: #Function<4.102239090 in FutureTest.test a future with no arguments/1> called with ()
```
