### PR TITLE
Compile error from defaults

### DIFF
--- a/lib/future.ex
+++ b/lib/future.ex
@@ -52,7 +52,7 @@ defmodule Future do
     quote do unquote(fun).(unquote_splicing(args)) end
   end
 
-  def value(pid, timeout // :infinity, default // { :error, :timeout }) do
+  def value(pid, timeout \\ :infinity, default \\ { :error, :timeout }) do
     unless Process.alive? pid do
       raise Error, message: "exhausted"
     end


### PR DESCRIPTION
Currently there is a compile error:
`lib/future.ex:55: using // for default arguments is deprecated, please use \\ instead`
